### PR TITLE
Fix FFI declaration for `open` (to be variadic).

### DIFF
--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -14,15 +14,15 @@
   :fun o_append I32: if Platform.is_windows (0x8 | 0x400)
   :fun o_binary I32: if Platform.is_windows (0x8000 | 0) // windows only
 
-  :fun open(path, flags, mode)
+  :fun open(path, flags, mode U32)
     if Platform.is_posix (
       @open_posix(path, flags, mode)
     |
       @open_windows(path, flags, mode)
     )
-  :ffi open_posix(path CPointer(U8), flags I32, mode U32) I32
+  :ffi variadic open_posix(path CPointer(U8), flags I32) I32
     :foreign_name open
-  :ffi open_windows(path CPointer(U8), flags I32, mode U32) I32
+  :ffi variadic open_windows(path CPointer(U8), flags I32) I32
     :foreign_name _open
 
   :fun read(fd, buf, count USize)


### PR DESCRIPTION
The C function `open` (on Windows, `_open`) takes two fixed
arguments, followed by a variadic optional third argument:

```
       int open(const char *pathname, int flags, ...
                  /* mode_t mode */ );
```
(see https://man7.org/linux/man-pages/man2/open.2.html)

On many platforms, the variadic calling convention will match
the fixed-argument calling convention for the same argument types.
But on some platforms (e.g. MacOS arm64), the variadic calling
convention uses registers/stack differently, so we must
declare it as `:ffi variadic` in Savi instead of just `:ffi`.

This commit fixes that issue, resolving issues with undefined `mode`
behavior of `File.Dumper` on MacOS arm64.
