### PR TITLE
Add `ext_name`, `base_name`, and `dir_name` convenience methods.

### DIFF
--- a/spec/File.Path.Spec.savi
+++ b/spec/File.Path.Spec.savi
@@ -1,0 +1,26 @@
+:class File.Path.Spec
+  :is Spec
+  :const describes: "File.Path"
+
+  :it "parses out the file extension of a path"
+    assert: File.Path.new(@env.root, "/a/b/c.d.e.txt").ext_name == "txt"
+    assert: File.Path.new(@env.root, "/a/b/c.d.e.").ext_name == ""
+    assert: File.Path.new(@env.root, "/a/b/c.d.e").ext_name == "e"
+    assert: File.Path.new(@env.root, "/a/b/c").ext_name == ""
+    assert: File.Path.new(@env.root, "/a/b/.gitignore").ext_name == "gitignore"
+    assert: File.Path.new(@env.root, "c").ext_name == ""
+    assert: File.Path.new(@env.root, "c.txt").ext_name == "txt"
+
+  :it "parses out the base name (file name) of a path"
+    assert: File.Path.new(@env.root, "/a/b/c.d.e.txt").base_name == "c.d.e.txt"
+    assert: File.Path.new(@env.root, "/a/b/c.d.e").base_name == "c.d.e"
+    assert: File.Path.new(@env.root, "/a/b/c").base_name == "c"
+    assert: File.Path.new(@env.root, "c").base_name == "c"
+    assert: File.Path.new(@env.root, "c.txt").base_name == "c.txt"
+
+  :it "parses out the directory name of a path"
+    assert: File.Path.new(@env.root, "/a/b/c.d.e.txt").dir_name == "/a/b"
+    assert: File.Path.new(@env.root, "/a/b/c.d.e").dir_name == "/a/b"
+    assert: File.Path.new(@env.root, "/a/b/c").dir_name == "/a/b"
+    assert: File.Path.new(@env.root, "c").dir_name == ""
+    assert: File.Path.new(@env.root, "c.txt").dir_name == ""

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -1,6 +1,7 @@
 :actor Main
   :new (env Env)
     Spec.Process.run(env, [
+      Spec.Run(File.Path.Spec).new(env)
       Spec.Run(File.Result.Spec).new(env)
       Spec.Run(File.Info.Spec).new(env)
       Spec.Run(File.Loader.Spec).new(env)

--- a/src/File.Path.savi
+++ b/src/File.Path.savi
@@ -67,6 +67,35 @@
   :fun hash USize: @string.hash
   :fun "=="(other File.Path.Any'box): @string == other.string
 
+  :: Return the file extension (everything after the last dot character).
+  ::
+  :: If there is no dot character, returns an empty string.
+  :fun ext_name String
+    @string.reverse_each_byte_with_index -> (byte, index |
+      return @string.trim(index + 1) if byte == '.'
+      return "" if byte == '/' || byte == '\\'
+    )
+    ""
+
+  :: Return the file name (everything after the last slash character),
+  :: including the file extension.
+  ::
+  :: If there is no slash character, returns the entire path string.
+  :fun base_name String
+    @string.reverse_each_byte_with_index -> (byte, index |
+      return @string.trim(index + 1) if byte == '/' || byte == '\\'
+    )
+    @string
+
+  :: Return the directory name (everything before the last slash character).
+  ::
+  :: If there is no slash character, returns an empty string.
+  :fun dir_name String
+    @string.reverse_each_byte_with_index -> (byte, index |
+      return @string.trim(0, index) if byte == '/' || byte == '\\'
+    )
+    ""
+
 :trait val File.Path.Readable
   :is File.Path.Any
   :fun read_permission: _ReadPermission


### PR DESCRIPTION
These are added to `File.Path.Any`, so that they will show up on all File Path types.